### PR TITLE
Fix IND$FILE

### DIFF
--- a/cms/ind$denc.c
+++ b/cms/ind$denc.c
@@ -334,7 +334,7 @@ int put_cnv(
             continue; /* ignore CR */
           } else if (c == 0x0a) {
             /* LF: signal EOR => write line */
-            if (writer) { /* writer is NULL in TST-mode */
+            if (writer && currLineLen > 0) { /* writer is NULL in TST-mode */
               (*writer)(currLineLen);
               ob = ob0;
               obuf_len = ob_len;


### PR DESCRIPTION
When a line is exactly 80 chars, checkWriteRecord() already writes it and resets currLineLen to 0. Without this guard, the subsequent LF would call writeRecord(0), which creates a 1-byte empty record (the len < 1 fallback in writeRecord).